### PR TITLE
Added parameter `forceRedirectOnOwnDelete=False` to `ActionsPanelView.__call__`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@ Changelog
   `meta_type` but consider it as a `class name` as with `dexterity`, the
   `meta_type` is always the same an no more useable to discriminate content.
   [gbastien]
+- Added parameter `forceRedirectOnOwnDelete=False` to `ActionsPanelView.__call__`,
+  when deleting an element, by default if current context is a faceted,
+  the user is not redirected but the page is reloaded, if we are removing the
+  page that holds the faceted then we need to redirect.
+  [gbastien]
 
 1.52 (2021-01-26)
 -----------------

--- a/src/imio/actionspanel/browser/actions_panel_own_delete.pt
+++ b/src/imio/actionspanel/browser/actions_panel_own_delete.pt
@@ -5,14 +5,14 @@
     <td class="noPadding" i18n:domain="plone" tal:define="dummy view/saveHasActions;">
       <tal:comment replace="nothing">Icon</tal:comment>
       <img tal:condition="useIcons" i18n:attributes="title" title="Delete"
-           tal:define="redirect python: view.forceRedirectOnOwnDelete and 'true' or 'null';"
            tal:attributes="src string:${view/portal_url}/delete_icon.png;
-                           onClick string:javascript:confirmDeleteObject(base_url='${context/absolute_url}', object_uid='${objectUID}', this, msgName=null, view_name='@@delete_givenuid', redirect=${redirect});;"
+                           onClick string:javascript:confirmDeleteObject(base_url='${context/absolute_url}', object_uid='${objectUID}', this, msgName=null, view_name='@@delete_givenuid', redirect=null);;"
            onClick="#" style="cursor:pointer"/>
 
       <tal:comment replace="nothing">Button</tal:comment>
       <input tal:condition="not: useIcons" type="button" i18n:attributes="value" value="Delete"
-             tal:attributes="onClick string:javascript:confirmDeleteObject(base_url='${context/absolute_url}', object_uid='${objectUID}', this, msgName=null, view_name='@@delete_givenuid', redirect=null);;"
+           tal:define="redirect python: view.forceRedirectOnOwnDelete and 'true' or 'null';"
+             tal:attributes="onClick string:javascript:confirmDeleteObject(base_url='${context/absolute_url}', object_uid='${objectUID}', this, msgName=null, view_name='@@delete_givenuid', redirect=${redirect});;"
              class="apButton apButtonAction apButtonAction_delete"/>
     </td>
 

--- a/src/imio/actionspanel/browser/actions_panel_own_delete.pt
+++ b/src/imio/actionspanel/browser/actions_panel_own_delete.pt
@@ -5,13 +5,14 @@
     <td class="noPadding" i18n:domain="plone" tal:define="dummy view/saveHasActions;">
       <tal:comment replace="nothing">Icon</tal:comment>
       <img tal:condition="useIcons" i18n:attributes="title" title="Delete"
+           tal:define="redirect python: view.forceRedirectOnOwnDelete and 'true' or 'null';"
            tal:attributes="src string:${view/portal_url}/delete_icon.png;
-                           onClick string:javascript:confirmDeleteObject(base_url='${context/absolute_url}', object_uid='${objectUID}', this);;"
+                           onClick string:javascript:confirmDeleteObject(base_url='${context/absolute_url}', object_uid='${objectUID}', this, msgName=null, view_name='@@delete_givenuid', redirect=${redirect});;"
            onClick="#" style="cursor:pointer"/>
 
       <tal:comment replace="nothing">Button</tal:comment>
       <input tal:condition="not: useIcons" type="button" i18n:attributes="value" value="Delete"
-             tal:attributes="onClick string:javascript:confirmDeleteObject(base_url='${context/absolute_url}', object_uid='${objectUID}', this);;"
+             tal:attributes="onClick string:javascript:confirmDeleteObject(base_url='${context/absolute_url}', object_uid='${objectUID}', this, msgName=null, view_name='@@delete_givenuid', redirect=null);;"
              class="apButton apButtonAction apButtonAction_delete"/>
     </td>
 

--- a/src/imio/actionspanel/browser/static/actionspanel.js
+++ b/src/imio/actionspanel/browser/static/actionspanel.js
@@ -1,5 +1,5 @@
 // Function that shows a popup that asks the user if he really wants to delete
-function confirmDeleteObject(base_url, object_uid, tag, msgName, view_name="@@delete_givenuid", redirect=null){
+function confirmDeleteObject(base_url, object_uid, tag, msgName=null, view_name="@@delete_givenuid", redirect=null){
     if (!msgName) {
         msgName = 'delete_confirm_message';
     }

--- a/src/imio/actionspanel/browser/views.py
+++ b/src/imio/actionspanel/browser/views.py
@@ -87,6 +87,7 @@ class ActionsPanelView(BrowserView):
                  showFolderContents=False,
                  arrowsPortalTypeAware=False,
                  markingInterface=None,
+                 forceRedirectOnOwnDelete=True,
                  **kwargs):
         """
           Master method that will render the content.
@@ -116,6 +117,11 @@ class ActionsPanelView(BrowserView):
         # order the elements of same portal_type together
         self.arrowsPortalTypeAware = arrowsPortalTypeAware
         self.markingInterface = markingInterface
+        # by default redirect is done only if not on a faceted
+        # but in some case, like when deleting an element that
+        # is the current faceted then it is necessary to redirect
+        # when displayed as icons, so as an element of a faceted, it does not apply
+        self.forceRedirectOnOwnDelete = forceRedirectOnOwnDelete
         self.kwargs = kwargs
         self.hasActions = False
         return self.index()


### PR DESCRIPTION
When deleting an element, by default if current context is a faceted, the user is not redirected but the page is reloaded, if we are removing the page that holds the faceted then we need to redirect.

See #PM-3359

https://support.imio.be/browse/PM-3359